### PR TITLE
WIP: Throw HTTP exceptions in the route controllers

### DIFF
--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * HTTP exception.
+ *
+ * HTTP exceptions are public-facing, so the messages are translated and should
+ * not reveal any sensitive information. Additional information can be attached
+ * for debugging.
+ *
+ * @package SatisPress
+ * @license GPL-2.0-or-later
+ * @since 0.3.0
+ */
+
+declare ( strict_types = 1 );
+
+namespace SatisPress\Exception;
+
+use SatisPress\Package;
+use SatisPress\Release;
+use Throwable;
+use WP_Http as HTTP;
+
+/**
+ * HTTP exception class.
+ *
+ * @since 0.3.0
+ */
+class HttpException extends \Exception implements ExceptionInterface {
+	/**
+	 * Exception data.
+	 *
+	 * @var array
+	 */
+	protected $data = [];
+
+	/**
+	 * HTTP status code.
+	 *
+	 * @var integer
+	 */
+	protected $status_code;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @param string    $message     Message.
+	 * @param integer   $status_code Optional. HTTP status code. Defaults to 500.
+	 * @param array     $data        Optional. Additional data.
+	 * @param integer   $code        Exception code.
+	 * @param Throwable $previous    Previous exception.
+	 */
+	public function __construct(
+		string $message,
+		int $status_code = HTTP::INTERNAL_SERVER_ERROR,
+		array $data = null,
+		int $code = 0,
+		Throwable $previous = null
+	) {
+		$this->data        = $data;
+		$this->status_code = $status_code;
+		$message           = $message ?: esc_html( 'Internal Server Error', 'satispress' );
+
+		parent::__construct( $message, $code, $previous );
+	}
+
+	/**
+	 * Create an exception for a forbidden resource request.
+	 *
+	 * @since 0.3.0.
+	 *
+	 * @param array     $data     Optional. Extra data for debugging.
+	 * @param int       $code     Optional. The Exception code.
+	 * @param Throwable $previous Optional. The previous throwable used for the exception chaining.
+	 * @return HTTPException
+	 */
+	public static function forForbiddenResource(
+		array $data = null,
+		int $code = 0,
+		Throwable $previous = null
+	): HTTPException {
+		$message = esc_html__( 'Sorry, you are not allowed to view this resource.', 'satispress' );
+
+		return new static( $message, HTTP::FORBIDDEN, $data, $code, $previous );
+	}
+
+	/**
+	 * Create an exception for an unknown package request.
+	 *
+	 * @since 0.3.0.
+	 *
+	 * @param string    $slug     Package slug.
+	 * @param array     $data     Optional. Extra data for debugging.
+	 * @param int       $code     Optional. The Exception code.
+	 * @param Throwable $previous Optional. The previous throwable used for the exception chaining.
+	 * @return HTTPException
+	 */
+	public static function forUknownPackage(
+		string $slug,
+		array $data = null,
+		int $code = 0,
+		Throwable $previous = null
+	): HTTPException {
+		$data    = [ 'slug' => $slug ];
+		$message = esc_html__( 'Package does not exist.', 'satispress' );
+
+		return new static( $message, HTTP::NOT_FOUND, $data, $code, $previous );
+	}
+
+	/**
+	 * Create an exception for a forbidden package request.
+	 *
+	 * @since 0.3.0.
+	 *
+	 * @param Package   $package  Package.
+	 * @param array     $data     Optional. Extra data for debugging.
+	 * @param int       $code     Optional. The Exception code.
+	 * @param Throwable $previous Optional. The previous throwable used for the exception chaining.
+	 * @return HTTPException
+	 */
+	public static function forForbiddenPackage(
+		Package $package,
+		array $data = null,
+		int $code = 0,
+		Throwable $previous = null
+	): HTTPException {
+		$data    = [ 'slug' => $package->get_slug() ];
+		$message = esc_html__( 'Sorry, you are not allowed to download this file.', 'satispress' );
+
+		return new static( $message, HTTP::FORBIDDEN, $data, $code, $previous );
+	}
+
+	/**
+	 * Create an exception for an invalid release request.
+	 *
+	 * @since 0.3.0.
+	 *
+	 * @param Package   $package  Package.
+	 * @param string    $version  Version.
+	 * @param array     $data     Optional. Extra data for debugging.
+	 * @param int       $code     Optional. The Exception code.
+	 * @param Throwable $previous Optional. The previous throwable used for the exception chaining.
+	 * @return HTTPException
+	 */
+	public static function forInvalidRelease(
+		Package $package,
+		string $version,
+		array $data = null,
+		int $code = 0,
+		Throwable $previous = null
+	): HTTPException {
+		$data = [
+			'slug'    => $package->get_slug(),
+			'version' => $version
+		];
+
+		$message = esc_html__( 'Package version does not exist.', 'satispress' );
+
+		return new static( $message, HTTP::NOT_FOUND, $data, $code, $previous );
+	}
+
+	/**
+	 * Create an exception for a missing release request.
+	 *
+	 * @since 0.3.0.
+	 *
+	 * @param Release   $release  Release.
+	 * @param array     $data     Optional. Extra data for debugging.
+	 * @param int       $code     Optional. The Exception code.
+	 * @param Throwable $previous Optional. The previous throwable used for the exception chaining.
+	 * @return HTTPException
+	 */
+	public static function forMissingRelease(
+		Release $release,
+		array $data = null,
+		int $code = 0,
+		Throwable $previous = null
+	): HTTPException {
+		$data = [
+			'file'    => $release->get_file(),
+			'slug'    => $release->get_package()->get_slug(),
+			'version' => $release->get_version(),
+		];
+
+		$message = esc_html__( 'Package artifact is missing.', 'satispress' );
+
+		return new static( $message, HTTP::NOT_FOUND, $data, $code, $previous );
+	}
+
+	/**
+	 * Retrieve exception data.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @return array
+	 */
+	public function getData() {
+		return $this->data;
+	}
+
+	/**
+	 * Retrieve the HTTP status code.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @return integer
+	 */
+	public function getStatusCode() {
+		return $this->status_code;
+	}
+}

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -205,4 +205,41 @@ class HttpException extends \Exception implements ExceptionInterface {
 	public function getStatusCode() {
 		return $this->status_code;
 	}
+
+	/**
+	 * Display the exception message and stop the request.
+	 *
+	 * @since 0.3.0
+	 */
+	public function displayMessage() {
+		$message = $this->getMessage();
+
+		if ( $this->can_show_extra_data() ) {
+			$data = $this->getData();
+			$data['file'] = $this->getFile();
+			$data['line'] = $this->getLine();
+
+			$message .= '<br>';
+			foreach( $data as $key => $value ) {
+				$message .= sprintf(
+					'<br><strong>%1$s:</strong> %2$s',
+					esc_html( ucwords( $key ) ),
+					esc_html( $value )
+				);
+			}
+		}
+
+		wp_die( wp_kses_post( $message ), $this->getStatusCode() );
+	}
+
+	/**
+	 * Whether extra data should be displayed.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @return boolean
+	 */
+	protected function can_show_extra_data() {
+		return current_user_can( 'manage_options' ) || defined( 'WP_DEBUG' ) && true === WP_DEBUG;
+	}
 }

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -96,7 +96,7 @@ class HttpException extends \Exception implements ExceptionInterface {
 	 * @param Throwable $previous Optional. The previous throwable used for the exception chaining.
 	 * @return HTTPException
 	 */
-	public static function forUknownPackage(
+	public static function forUnknownPackage(
 		string $slug,
 		array $data = null,
 		int $code = 0,

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -2,10 +2,6 @@
 /**
  * HTTP exception.
  *
- * HTTP exceptions are public-facing, so the messages are translated and should
- * not reveal any sensitive information. Additional information can be attached
- * for debugging.
- *
  * @package SatisPress
  * @license GPL-2.0-or-later
  * @since 0.3.0
@@ -60,7 +56,7 @@ class HttpException extends \Exception implements ExceptionInterface {
 	) {
 		$this->data        = $data;
 		$this->status_code = $status_code;
-		$message           = $message ?: esc_html( 'Internal Server Error', 'satispress' );
+		$message           = $message ?: 'Internal Server Error';
 
 		parent::__construct( $message, $code, $previous );
 	}
@@ -80,7 +76,7 @@ class HttpException extends \Exception implements ExceptionInterface {
 		int $code = 0,
 		Throwable $previous = null
 	): HTTPException {
-		$message = esc_html__( 'Sorry, you are not allowed to view this resource.', 'satispress' );
+		$message = 'Sorry, you are not allowed to view this resource.';
 
 		return new static( $message, HTTP::FORBIDDEN, $data, $code, $previous );
 	}
@@ -103,7 +99,7 @@ class HttpException extends \Exception implements ExceptionInterface {
 		Throwable $previous = null
 	): HTTPException {
 		$data    = [ 'slug' => $slug ];
-		$message = esc_html__( 'Package does not exist.', 'satispress' );
+		$message = 'Package does not exist.';
 
 		return new static( $message, HTTP::NOT_FOUND, $data, $code, $previous );
 	}
@@ -126,7 +122,7 @@ class HttpException extends \Exception implements ExceptionInterface {
 		Throwable $previous = null
 	): HTTPException {
 		$data    = [ 'slug' => $package->get_slug() ];
-		$message = esc_html__( 'Sorry, you are not allowed to download this file.', 'satispress' );
+		$message = 'Sorry, you are not allowed to download this file.';
 
 		return new static( $message, HTTP::FORBIDDEN, $data, $code, $previous );
 	}
@@ -155,7 +151,7 @@ class HttpException extends \Exception implements ExceptionInterface {
 			'version' => $version
 		];
 
-		$message = esc_html__( 'Package version does not exist.', 'satispress' );
+		$message = 'Package version does not exist.';
 
 		return new static( $message, HTTP::NOT_FOUND, $data, $code, $previous );
 	}
@@ -183,7 +179,7 @@ class HttpException extends \Exception implements ExceptionInterface {
 			'version' => $release->get_version(),
 		];
 
-		$message = esc_html__( 'Package artifact is missing.', 'satispress' );
+		$message = 'Package artifact is missing.';
 
 		return new static( $message, HTTP::NOT_FOUND, $data, $code, $previous );
 	}

--- a/src/Provider/RequestHandler.php
+++ b/src/Provider/RequestHandler.php
@@ -86,28 +86,7 @@ class RequestHandler extends AbstractHookProvider {
 					->handle_request( $this->request );
 			}
 		} catch ( HTTPException $e ) {
-			$message = $e->getMessage();
-
-			// Show extra exception data to administrators or when in debugging mode.
-			if (
-				current_user_can( 'manage_options' )
-				|| defined( 'WP_DEBUG' ) && true === WP_DEBUG
-			) {
-				$data = $e->getData();
-				$data['file'] = $e->getFile();
-				$data['line'] = $e->getLine();
-
-				$message .= '<br>';
-				foreach( $data as $key => $value ) {
-					$message .= sprintf(
-						'<br><strong>%1$s</strong>: %2$s',
-						esc_html( ucwords( $key ) ),
-						esc_html( $value )
-					);
-				}
-			}
-
-			wp_die( wp_kses_post( $message ), $e->getStatusCode() );
+			$e->displayMessage();
 		}
 		exit;
 	}

--- a/src/Route/Composer.php
+++ b/src/Route/Composer.php
@@ -11,15 +11,15 @@ declare ( strict_types = 1 );
 
 namespace SatisPress\Route;
 
+use SatisPress\Capabilities;
 use SatisPress\Exception\ExceptionInterface;
 use SatisPress\Exception\FileNotFound;
-use SatisPress\Capabilities;
+use SatisPress\Exception\HTTPException;
+use SatisPress\HTTP\Request;
 use SatisPress\Package;
 use SatisPress\PackageManager;
 use SatisPress\ReleaseManager;
 use SatisPress\VersionParser;
-use SatisPress\HTTP\Request;
-use WP_Http as HTTP;
 
 /**
  * Class for rendering packages.json for Composer.
@@ -72,7 +72,7 @@ class Composer implements Route {
 	 */
 	public function handle_request( Request $request ) {
 		if ( ! current_user_can( Capabilities::VIEW_PACKAGES ) ) {
-			$this->send_403();
+			throw HTTPException::forForbiddenResource();
 		}
 
 		header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ) );
@@ -144,16 +144,5 @@ class Composer implements Route {
 		}
 
 		return $item;
-	}
-
-	/**
-	 * Send a forbidden response.
-	 *
-	 * @since 0.3.0
-	 */
-	protected function send_403() {
-		status_header( HTTP::FORBIDDEN );
-		nocache_headers();
-		wp_die( esc_html__( 'Sorry, you are not allowed to view this resource.', 'satispress' ) );
 	}
 }

--- a/src/Route/Download.php
+++ b/src/Route/Download.php
@@ -93,7 +93,7 @@ class Download implements Route {
 
 		// Send a 404 response if the package doesn't exist.
 		if ( ! isset( $packages[ $slug ] ) ) {
-			throw HTTPException::forUknownPackage( $slug );
+			throw HTTPException::forUnknownPackage( $slug );
 		}
 
 		$package = $packages[ $slug ];

--- a/src/Route/Download.php
+++ b/src/Route/Download.php
@@ -14,6 +14,7 @@ namespace SatisPress\Route;
 use function SatisPress\send_file;
 use SatisPress\Capabilities;
 use SatisPress\Exception\ExceptionInterface;
+use SatisPress\Exception\HTTPException;
 use SatisPress\Exception\InvalidReleaseVersion;
 use SatisPress\Package;
 use SatisPress\PackageManager;
@@ -75,12 +76,12 @@ class Download implements Route {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		if ( ! current_user_can( Capabilities::DOWNLOAD_PACKAGES ) ) {
-			$this->send_403();
+			throw HTTPException::forForbiddenResource();
 		}
 
 		$slug = sanitize_key( $request['slug'] );
 		if ( empty( $slug ) ) {
-			$this->send_404();
+			throw HTTPException::forUnknownPackage( $slug );
 		}
 
 		$version = '';
@@ -92,14 +93,14 @@ class Download implements Route {
 
 		// Send a 404 response if the package doesn't exist.
 		if ( ! isset( $packages[ $slug ] ) ) {
-			$this->send_404();
+			throw HTTPException::forUknownPackage( $slug );
 		}
 
 		$package = $packages[ $slug ];
 
 		// Ensure the user has access to download the package.
 		if ( ! current_user_can( Capabilities::DOWNLOAD_PACKAGE, $package->get_slug() ) ) {
-			$this->send_403();
+			throw HTTPException::forForbiddenPackage( $package );
 		}
 
 		$this->send_package( $package, $version );
@@ -124,7 +125,7 @@ class Download implements Route {
 		try {
 			$release = $package->get_release( $version );
 		} catch ( InvalidReleaseVersion $e ) {
-			$this->send_404();
+			throw HTTPException::forInvalidRelease( $package, $version );
 		}
 
 		// Archive the currently installed version if the artifact doesn't
@@ -140,45 +141,10 @@ class Download implements Route {
 
 		// Send a 404 if the release isn't available.
 		if ( ! $this->release_manager->exists( $release ) ) {
-			$this->send_404();
+			throw HTTPException::forMissingRelease( $release );
 		}
 
 		$this->release_manager->send( $release );
 		exit;
-	}
-
-	/**
-	 * Send a forbidden response.
-	 *
-	 * @since 0.3.0
-	 */
-	protected function send_403() {
-		$this->send_error_response(
-			esc_html__( 'Sorry, you are not allowed to download this file.', 'satispress' ),
-			HTTP::NOT_FOUND
-		);
-	}
-
-	/**
-	 * Send a not found response.
-	 *
-	 * @since 0.3.0
-	 */
-	protected function send_404() {
-		$this->send_error_response(
-			esc_html__( 'Package does not exist.', 'satispress' ),
-			HTTP::NOT_FOUND
-		);
-	}
-
-	/**
-	 * Send a response.
-	 *
-	 * @since 0.3.0
-	 */
-	protected function send_error_response( $message, $status ) {
-		status_header( $status );
-		nocache_headers();
-		wp_die( $message );
 	}
 }


### PR DESCRIPTION
This removes the methods for sending error responses and makes response handling more generic. The route controllers still need to return responses for valid requests to fully abstract response handling.