### PR TITLE
Move the packages.json generation into a repository transformer. See #39

### DIFF
--- a/src/Route/Composer.php
+++ b/src/Route/Composer.php
@@ -19,9 +19,8 @@ use SatisPress\HTTP\Request;
 use SatisPress\HTTP\Response;
 use SatisPress\HTTP\ResponseBody\JsonBody;
 use SatisPress\Package;
-use SatisPress\ReleaseManager;
 use SatisPress\Repository\PackageRepository;
-use SatisPress\VersionParser;
+use SatisPress\Transformer\PackageRepositoryTransformer;
 use WP_Http as HTTP;
 
 /**
@@ -38,32 +37,23 @@ class Composer implements Route {
 	protected $repository;
 
 	/**
-	 * Release manager.
+	 * Repository transformer.
 	 *
-	 * @var ReleaseManager
+	 * @var PackageRepositoryTransformer
 	 */
-	protected $release_manager;
-
-	/**
-	 * Version parser.
-	 *
-	 * @var VersionParser
-	 */
-	protected $version_parser;
+	protected $transformer;
 
 	/**
 	 * Constructor.
 	 *
 	 * @since 0.3.0
 	 *
-	 * @param PackageRepository $repository      Package repository.
-	 * @param ReleaseManager    $release_manager Release manager.
-	 * @param VersionParser     $version_parser  Version parser.
+	 * @param PackageRepository            $repository  Package repository.
+	 * @param PackageRepositoryTransformer $transformer Package repository transformer.
 	 */
-	public function __construct( PackageRepository $repository, ReleaseManager $release_manager, VersionParser $version_parser ) {
-		$this->repository      = $repository;
-		$this->release_manager = $release_manager;
-		$this->version_parser  = $version_parser;
+	public function __construct( PackageRepository $repository, PackageRepositoryTransformer $transformer ) {
+		$this->repository  = $repository;
+		$this->transformer = $transformer;
 	}
 
 	/**
@@ -81,82 +71,9 @@ class Composer implements Route {
 		}
 
 		return new Response(
-			new JsonBody( [ 'packages' => $this->get_items() ] ),
+			new JsonBody( $this->transformer->transform( $this->repository ) ),
 			HTTP::OK,
 			[ 'Content-Type' => 'application/json; charset=' . get_option( 'blog_charset' ) ]
 		);
-	}
-
-	/**
-	 * Retrieves a collection of packages.
-	 *
-	 * @since 0.3.0
-	 *
-	 * @return array
-	 */
-	public function get_items(): array {
-		$items = [];
-
-		foreach ( $this->repository->all() as $slug => $package ) {
-			if ( ! $package->has_releases() ) {
-				continue;
-			}
-
-			try {
-				$item = $this->prepare_item_for_response( $package );
-
-				// Skip if there aren't any viewable releases.
-				if ( empty( $item ) ) {
-					continue;
-				}
-
-				$items[ $package->get_name() ] = $item;
-			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			} catch ( FileNotFound $e ) {
-				// Continue to allow valid items to be served.
-			}
-		}
-
-		return $items;
-	}
-
-	/**
-	 * Prepare a package for response.
-	 *
-	 * @param Package $package Package instance.
-	 * @return array
-	 */
-	public function prepare_item_for_response( Package $package ): array {
-		$item = [];
-
-		foreach ( $package->get_releases() as $release ) {
-			// Skip if the current user can't view this release.
-			if ( ! current_user_can( Capabilities::VIEW_PACKAGE, $package, $release ) ) {
-				continue;
-			}
-
-			$item[ $release->get_version() ] = [
-				'name'               => $package->get_name(),
-				'version'            => $release->get_version(),
-				'version_normalized' => $this->version_parser->normalize( $release->get_version() ),
-				'dist'               => [
-					'type'   => 'zip',
-					'url'    => $release->get_download_url(),
-					'shasum' => $this->release_manager->checksum( 'sha1', $release ),
-				],
-				'require'            => [
-					'composer/installers' => '^1.0',
-				],
-				'type'               => $package->get_type(),
-				'authors'            => [
-					'name'     => $package->get_author(),
-					'homepage' => esc_url( $package->get_author_url() ),
-				],
-				'description'        => $package->get_description(),
-				'homepage'           => $package->get_homepage(),
-			];
-		}
-
-		return $item;
 	}
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,6 +26,7 @@ use SatisPress\Provider;
 use SatisPress\Repository;
 use SatisPress\Screen;
 use SatisPress\Storage;
+use SatisPress\Transformer\ComposerRepositoryTransformer;
 
 /**
  * Plugin service provider class.
@@ -215,8 +216,7 @@ class ServiceProvider implements ServiceProviderInterface {
 					$container['repository.whitelist'],
 					$container['package.factory']
 				),
-				$container['release.manager'],
-				$container['version.parser']
+				$container['transformer.composer_repository']
 			);
 		};
 
@@ -249,6 +249,13 @@ class ServiceProvider implements ServiceProviderInterface {
 
 		$container['storage'] = function( $container ) {
 			return new Storage\Local( $container['cache.path'] );
+		};
+
+		$container['transformer.composer_repository'] = function( $container ) {
+			return new ComposerRepositoryTransformer(
+				$container['release.manager'],
+				$container['version.parser']
+			);
 		};
 
 		$container['version.parser'] = function( $container ) {

--- a/src/Transformer/ComposerRepositoryTransformer.php
+++ b/src/Transformer/ComposerRepositoryTransformer.php
@@ -62,8 +62,6 @@ class ComposerRepositoryTransformer implements PackageRepositoryTransformer {
 		$items = [];
 
 		foreach ( $repository->all() as $slug => $package ) {
-			// @todo Transform the package into a Composer package?
-
 			if ( ! $package->has_releases() ) {
 				continue;
 			}

--- a/src/Transformer/ComposerRepositoryTransformer.php
+++ b/src/Transformer/ComposerRepositoryTransformer.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Composer repository transformer.
+ *
+ * @package SatisPress
+ * @license GPL-2.0-or-later
+ * @since 0.3.0
+ */
+
+declare ( strict_types = 1 );
+
+namespace SatisPress\Transformer;
+
+use SatisPress\Capabilities;
+use SatisPress\Package;
+use SatisPress\ReleaseManager;
+use SatisPress\Repository\PackageRepository;
+use SatisPress\VersionParser;
+
+/**
+ * Composer repository transformer class.
+ *
+ * @since 0.3.0
+ */
+class ComposerRepositoryTransformer implements PackageRepositoryTransformer {
+	/**
+	 * Release manager.
+	 *
+	 * @var ReleaseManager
+	 */
+	protected $release_manager;
+
+	/**
+	 * Version parser.
+	 *
+	 * @var VersionParser
+	 */
+	protected $version_parser;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @param ReleaseManager $release_manager Release manager.
+	 * @param VersionParser  $version_parser  Version parser.
+	 */
+	public function __construct( ReleaseManager $release_manager, VersionParser $version_parser ) {
+		$this->release_manager = $release_manager;
+		$this->version_parser  = $version_parser;
+	}
+
+	/**
+	 * Transform a repository of packages into the format used in packages.json.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @param PackageRepository $repository Package repository.
+	 * @return array
+	 */
+	public function transform( PackageRepository $repository ) {
+		$items = [];
+
+		foreach ( $repository->all() as $slug => $package ) {
+			// @todo Transform the package into a Composer package?
+
+			if ( ! $package->has_releases() ) {
+				continue;
+			}
+
+			try {
+				$item = $this->transform_item( $package );
+
+				// Skip if there aren't any viewable releases.
+				if ( empty( $item ) ) {
+					continue;
+				}
+
+				$items[ $package->get_name() ] = $item;
+			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			} catch ( FileNotFound $e ) {
+				// Continue to allow valid items to be served.
+			}
+		}
+
+		return [ 'packages' => $items ];
+	}
+
+	/**
+	 * Transform an item.
+	 *
+	 * @param Package $package Package instance.
+	 * @return array
+	 */
+	protected function transform_item( Package $package ): array {
+		$item = [];
+
+		foreach ( $package->get_releases() as $release ) {
+			// Skip if the current user can't view this release.
+			if ( ! current_user_can( Capabilities::VIEW_PACKAGE, $package, $release ) ) {
+				continue;
+			}
+
+			$item[ $release->get_version() ] = [
+				'name'               => $package->get_name(),
+				'version'            => $release->get_version(),
+				'version_normalized' => $this->version_parser->normalize( $release->get_version() ),
+				'dist'               => [
+					'type'   => 'zip',
+					'url'    => $release->get_download_url(),
+					'shasum' => $this->release_manager->checksum( 'sha1', $release ),
+				],
+				'require'            => [
+					'composer/installers' => '^1.0',
+				],
+				'type'               => $package->get_type(),
+				'authors'            => [
+					'name'     => $package->get_author(),
+					'homepage' => esc_url( $package->get_author_url() ),
+				],
+				'description'        => $package->get_description(),
+				'homepage'           => $package->get_homepage(),
+			];
+		}
+
+		return $item;
+	}
+}

--- a/src/Transformer/PackageRepositoryTransformer.php
+++ b/src/Transformer/PackageRepositoryTransformer.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Package repository transformer interface.
+ *
+ * @package SatisPress
+ * @license GPL-2.0-or-later
+ * @since 0.3.0
+ */
+
+declare ( strict_types = 1 );
+
+namespace SatisPress\Transformer;
+
+use SatisPress\Repository\PackageRepository;
+
+/**
+ * Package repository transformer interface.
+ *
+ * @since 0.3.0
+ */
+interface PackageRepositoryTransformer {
+	/**
+	 * Transform a package repository.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @param PackageRepository $repository Package repository.
+	 * @return mixed
+	 */
+	public function transform( PackageRepository $repository );
+}


### PR DESCRIPTION
This allows decorators to wrap the transformer to add custom caching implementations.