### PR TITLE
Load the plugin at plugins_loaded:5

### DIFF
--- a/satispress.php
+++ b/satispress.php
@@ -65,13 +65,4 @@ $satispress = plugin()
 	->register_hooks( $satispress_container->get( 'hooks.activation' ) )
 	->register_hooks( $satispress_container->get( 'hooks.deactivation' ) );
 
-// Authentication handlers need to be registered early.
-add_action(
-	'plugins_loaded',
-	function() use ( $satispress, $satispress_container ) {
-		$satispress->register_hooks( $satispress_container->get( 'hooks.authentication' ) );
-	},
-	5
-);
-
-add_action( 'plugins_loaded', [ $satispress, 'compose' ] );
+add_action( 'plugins_loaded', [ $satispress, 'compose' ], 5 );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -26,7 +26,7 @@ class Plugin extends BasePlugin implements Composable {
 	 * @since 0.3.0
 	 */
 	public function compose() {
-		$container = $this->container;
+		$container = $this->get_container();
 
 		/**
 		 * Start composing the object graph in SatisPress.
@@ -40,6 +40,7 @@ class Plugin extends BasePlugin implements Composable {
 
 		// Register hook providers.
 		$this
+			->register_hooks( $container->get( 'hooks.authentication' ) )
 			->register_hooks( $container->get( 'hooks.i18n' ) )
 			->register_hooks( $container->get( 'hooks.capabilities' ) )
 			->register_hooks( $container->get( 'hooks.rewrite_rules' ) )


### PR DESCRIPTION
Splitting the priority when the plugin is loaded meant that some extensions wouldn't be able to use the `satispress_compose` action to modify the filter, so they would have to load before SatisPress and check to make sure it exists first. The [current logging example](https://github.com/blazersix/satispress/blob/9adbe8efc41e4312ffe8339685a9072e748d74a5/docs/logging.md) shows how this has to be done.

Registering the entire plugin at `plugins_loaded:5` makes it cleaner for extensions to hook in without needing to check to see if SatisPress exists first.

```php
add_action( 'satispress_compose', function( $plugin, $container ) {
    // $container['logger'] = ...
} );
```

@GaryJones Do you see any issue with loading everything this early?